### PR TITLE
[Fix] Barcode hash

### DIFF
--- a/modules/Barcode.js
+++ b/modules/Barcode.js
@@ -8,8 +8,8 @@ const rgbHex = require('rgb-hex');
 const colorSort = require('color-sort');
 const average = require('image-average-color');
 
-function createHash(...items){
-  return crypto.createHash('md5').update(items.toString()).digest("hex");
+function createHash(items){
+  return crypto.createHash('md5').update(JSON.stringify(items)).digest("hex");
 }
 
 function createConfig(orientation, fit, num, width, height, paths, order, sort){

--- a/routes/barcode.js
+++ b/routes/barcode.js
@@ -78,7 +78,7 @@ router.get('/', async (req, res) => {
   
   try {
     const params = {width, height, dateFrom, dateTo, timeFrom, timeTo, orientation, fit, order, sort, share };
-    const hash = barcode.createHash(JSON.stringify({...params}));
+    const hash = barcode.createHash(params);
     const finalFilepath = `${process.env.RESULT_FOLDER}/output_${hash}.jpg`;
 
     return queue.add({

--- a/routes/barcode.js
+++ b/routes/barcode.js
@@ -78,7 +78,7 @@ router.get('/', async (req, res) => {
   
   try {
     const params = {width, height, dateFrom, dateTo, timeFrom, timeTo, orientation, fit, order, sort, share };
-    const hash = barcode.createHash({...params});
+    const hash = barcode.createHash(JSON.stringify({...params}));
     const finalFilepath = `${process.env.RESULT_FOLDER}/output_${hash}.jpg`;
 
     return queue.add({


### PR DESCRIPTION
## Description
When refactoring I turned the barcode params into an Object. Creating a hash from said spread Object resulted in the same hash, returning the cached barcode for every query.

## Implementation
- Stringify params object

## .env changes
None

## Additional requirements
None
