### PR TITLE
[Doc] PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+## Description
+// A description of the feature/issue
+//If this is linked to an open GitHub Issue, add “Fixes #[Issue Number]”.
+
+## Implementation
+//Points of interests in the implementation, described as a list of steps
+
+## Screenshot
+//If the feature is visual. Or a before/after in case of an update
+
+## .env changes
+//Required variables to run locally -- the values should be saved in LastPass
+
+## Additional requirements
+//Required modules or properties to run locally (e.g. Needs to run `npm i` again, or CAPI key needed a new property)
+
+_[Optional] A funny image or GIF that relates to the bug/feature at hand._


### PR DESCRIPTION
## Description
Adds a PR template

## Implementation
Create doc in `.github` folder with name `PULL_REQUEST_TEMPLATE.md` -- GitHub will pull it automatically
