### PR TITLE
[Fix] Barcode fail

### DIFF
--- a/modules/Barcode.js
+++ b/modules/Barcode.js
@@ -125,9 +125,9 @@ function getDownloadPromise(config, imageItem) {
         resolve(winState);
       });
 
-      writeStream.on('error', (err) => { reject(failStated); });
-      downloadStream.on('error', (err) => { reject(failState); });
-      resizeTransform.on('error', (err) => { reject(failState); });
+      writeStream.on('error', (err) => { resolve(failStated); });
+      downloadStream.on('error', (err) => { resolve(failState); });
+      resizeTransform.on('error', (err) => { resolve(failState); });
     });
   })
   .catch(function(err){


### PR DESCRIPTION
## Description
Barcode didn't post to Slack. The reason was that some images not found didn't get ignored and stopped the generation of the image

## Implementation
- resolve the download promise with failed state instead of rejecting.

## .env changes
None

## Additional requirements
None

![giphy](https://user-images.githubusercontent.com/3882381/52279052-7fd07080-2950-11e9-8623-31ddec7921f9.gif)

