### PR TITLE
[Fix] Fixes heroku link in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 An API endpoint to gather all of the main images used in FT articles from a provided date range, the last 24 hours for example, and squash them (width wise) to give one condensed image that represents the news. The final result looks similar to a coloured barcode.
 
 Can be tested out here:
-[https://ft-barcode.herokuapp.com/](https://ft-barcode.herokuapp.com/)
+[https://ftlabs-barcode.herokuapp.com/](https://ftlabs-barcode.herokuapp.com/)
 
 ## Installation
 


### PR DESCRIPTION
## Description
Fixes a link in the read me that was linking to an incorrect location

## Implementation
Link correction has been made

## Screenshot
n/a

## .env changes
n/a

## Additional requirements
n/a